### PR TITLE
Mode strict et all pour fromCodePac

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,58 @@ import cpf from './data/cpf.json' assert { type: 'json' }
  */
 
 /**
+ * @deprecated since version 1.4.0
  * @param {String} code
- * @returns {UnifiedCulture}
+ * @returns {?UnifiedCulture}
  */
 export function fromCodePac (code) {
-  return cpf.find(({ cultures_pac }) => cultures_pac.some(culture => culture.code === code))
+  console.warn("fromCodePac is deprecated, use fromCodePacFirst instead")
+
+  return fromCodePacFirst(code)
 }
+
+/**
+ * @param {String} code
+ * @returns {?UnifiedCulture}
+ */
+export function fromCodePacStrict (code) {
+  let allMatchs = fromCodePacAll(code)
+  let codes = allMatchs.map(({ code_cpf }) => code_cpf)
+  let commonPrefix = codes.reduce((acc, code) => {
+    let i = 0
+    while (code[i] === acc[i] && i < acc.length) {
+      i++
+    }
+    return code.slice(0, i)
+  }, codes[0]).replace(/\.$/, "").split(".")
+
+  if (commonPrefix.length < 2) {
+    return null;
+  }
+
+  let commonPrefixString = commonPrefix.join(".")
+  return cpf.find(({ code_cpf }) => code_cpf === commonPrefixString)
+}
+
+/**
+ * @param {String} code
+ * @returns {?UnifiedCulture}
+ */
+export function fromCodePacFirst (code) {
+  return fromCodePacAll(code)[0] || null
+}
+
+/**
+ * @param {String} code
+ * @returns {UnifiedCulture[]}
+ */
+export function fromCodePacAll (code) {
+  return cpf.filter(
+    ({ cultures_pac }) => cultures_pac.some(culture => culture.code === code)
+  )
+}
+
+
 
 /**
  * @param {String} code
@@ -70,8 +116,8 @@ export function toBoolean (excelLikeBoolean) {
 
 /**
  *
- * @param {UnifiedCulture[]} codes
- * @returns {function<String>:UnifiedCulture[]}
+ * @param {UnifiedCulture[]} cultures
+ * @returns {function(String):UnifiedCulture[]}
  */
 export function createCpfResolver (cultures) {
   const HAS_MANY_RE = /,/g

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     ".": {
       "import": "./index.js",
       "require": "./dist/cjs/index.cjs"
-    }
+    },
+    "./data/*.json": "./data/*.json"
   },
   "scripts": {
     "build": "npm run build:json && npm run build:cjs && npm run build:types",


### PR DESCRIPTION
Actuellement la fonction `fromCodePac` ne sélectionne que des codes CPF listés dans le fichier original `correspondance.csv`, et s'il y a plusieurs correspondances, retourne le premier.

En conséquence, un code PAC comme `AGR` renvoie `01.23.11 (Pomelos et pamplemousses)` parce que c'est le premier de la liste `01.23.11,01.23.12,01.23.13,01.23.14,01.23.19`.

Cette PR propose :
* un nouveau mode `strict`, où dans de telles situations, on essaie de trouver le plus petit code commun à la liste, ici `01.23.1 (Agrumes)`, et si on ne trouve pas on ne retourne rien (codes `ACA` ou `ZZZ` par exemple).
* un nouveau mode `all`, qui renvoie toutes les cultures désignées comme correspondantes

Le mode `firstmatch` reste le mode par défaut pour ne pas cause de breaking change, mais ça peut se changer :)